### PR TITLE
fix: discard non-surface polygons during etch and grow

### DIFF
--- a/src/ruby/mask_data.rb
+++ b/src/ruby/mask_data.rb
@@ -318,11 +318,9 @@ module XS
       end
   
       d &= RBA::Region::new(into_data)
-      
-      poly = []
-      d.each { |p| poly << p }
-      return poly
-  
+
+      # Keep polygons touching the surface
+      return d.interacting(me).each.collect { |p| p }
     end
 
     # Computes the convolution of the edge sequence with the kernel 


### PR DESCRIPTION
Addresses issues klayoutmatthias/xsection#22 and klayoutmatthias/xsection#24

The etch/grow function does not consider the masking aspect of the of the underlying geometry, resulting in non-physical operations. That is, an hermetically sealed bubble can be etched or deposited into without creating a hole in it. The operation goes through all layers, even though no `:through` argument is specified.

This fix introduces a filter to discard all regions that are not connected to the surface at one point.
It might break the `:through`'s intended behavior. I have not tested that parameter.

